### PR TITLE
Update to support Rails 4.0

### DIFF
--- a/semrush.gemspec
+++ b/semrush.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "activesupport", "~> 3.2.0"
+  s.add_dependency "activesupport", ">= 3.2.0"
   s.add_dependency('pony', '>= 1.0.0')
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.0.0"


### PR DESCRIPTION
It appears that all that is necessary for Rails 4 support is to accept the newer activesupport gem. So far I'm not seeing any errors using it this way.
