### PR TITLE
Adds :display_date to the available parameters on a basics report

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -58,6 +58,7 @@ You may use the following parameters:
   :export_columns # (String) select the columns you want to fetch, for instance: :export_columns => "Dn,Rk"
   :display_sort   # (String) select the column and the order you want to sort with, for instance: :display_sort => 'tr_asc'
   :display_filter # (String) list of filters for the report, separated by '|' (maximum number - 25). A filter consists of <sign>|<field>|<operation>|<value> (read http://www.semrush.com/api), for instance: :display_filter => '+|Po|Lt|5'
+  :display_date	  # (String) select the date for the report data, in the format: YYYYMM15
 
 Some examples:
 

--- a/lib/semrush.rb
+++ b/lib/semrush.rb
@@ -8,7 +8,7 @@ require 'semrush/exception'
 require 'semrush/report'
 
 module Semrush
-  API_REPORT_URL = "http://api.semrush.com/?type=%REPORT_TYPE%&%REQUEST_TYPE%=%REQUEST%&key=%API_KEY%&display_limit=%LIMIT%&display_offset=%OFFSET%&export=api&database=%DB%&export_columns=%EXPORT_COLUMNS%&display_sort=%DISPLAY_SORT%&display_filter=%DISPLAY_FILTER%"
+  API_REPORT_URL = "http://api.semrush.com/?type=%REPORT_TYPE%&%REQUEST_TYPE%=%REQUEST%&key=%API_KEY%&display_limit=%LIMIT%&display_offset=%OFFSET%&export=api&database=%DB%&export_columns=%EXPORT_COLUMNS%&display_sort=%DISPLAY_SORT%&display_filter=%DISPLAY_FILTER%&display_date=%DISPLAY_DATE%"
   API_UNITS_URL = "http://www.semrush.com/users/countapiunits.html?key=%API_KEY%"
   mattr_accessor :api_key
   @@api_key = ""

--- a/lib/semrush/report.rb
+++ b/lib/semrush/report.rb
@@ -306,7 +306,7 @@ module Semrush
       params.delete(:db) unless DBS.include?(params[:db].try(:to_sym))
       params.delete(:report_type) unless REPORT_TYPES.include?(params[:report_type].try(:to_sym))
       params.delete(:request_type) unless REQUEST_TYPES.include?(params[:request_type].try(:to_sym))
-      @parameters = {:db => "us", :api_key => Semrush.api_key, :limit => "", :offset => "", :export_columns => "", :display_sort => "", :display_filter => ""}.merge(@parameters).merge(params)
+      @parameters = {:db => "us", :api_key => Semrush.api_key, :limit => "", :offset => "", :export_columns => "", :display_sort => "", :display_filter => "", :display_date => ""}.merge(@parameters).merge(params)
       raise Semrush::Exception::Nolimit.new(self, "The limit parameter is missing: a limit is required.") unless @parameters[:limit].present? && @parameters[:limit].to_i>0
       raise Semrush::Exception::BadArgument.new(self, "Request parameter is missing: Domain name, URL, or keywords are required.") unless @parameters[:request].present?
       raise Semrush::Exception::BadArgument.new(self, "Bad db: #{@parameters[:db]}") unless DBS.include?(@parameters[:db].try(:to_sym))

--- a/spec/semrush/report_spec.rb
+++ b/spec/semrush/report_spec.rb
@@ -76,6 +76,11 @@ describe "Reports:" do
         lambda{Semrush::Report.phrase("calvin & hobbs").send(method, :db => :us, :limit => 5)}.should_not raise_error
       end
     end
+    [:basics].each do |method|
+      it "accepts a display date parameter" do
+        lambda{Semrush::Report.phrase("calvin & hobbs").send(method, :db => :us, :limit => 5, :display_date => Date.today.strftime('%Y%m%d'))}.should_not raise_error
+      end
+    end
   end
 
   describe Semrush, "parameters positions in reports" do


### PR DESCRIPTION
Adds :display_date to the available parameters on a basics report, for phrase_this keyword type reports. 

Note, you need to be subscribed to their "Guru" option in order to access historical data
