### PR TITLE
fixes map bug with filtered organic report that has no results

### DIFF
--- a/lib/semrush/report.rb
+++ b/lib/semrush/report.rb
@@ -333,6 +333,7 @@ module Semrush
     end
 
     def parse(text = "")
+      return [] if text.empty?
       csv = CSV.parse(text.to_s, :col_sep => ";")
       data = {}
       format_key = lambda do |k|

--- a/spec/semrush/report_spec.rb
+++ b/spec/semrush/report_spec.rb
@@ -21,6 +21,11 @@ describe "Reports:" do
     it "initializes correctly with params" do
       lambda{Semrush::Report.domain("seobook.com", :db => :us)}.should_not raise_error
     end
+
+    it 'handles domains with no keywords' do
+      Semrush::Report.domain("sleepingexpert.net", :db => :us).organic(limit: 5, display_filter: '+|Tr|Gt|0.0|+|Po|Lt|11').should eq []
+    end
+
     [:basics, :organic, :adwords].each do |method|
       it "works with the method '#{method}'" do
         lambda{@parsed = Semrush::Report.domain("seobook.com").send(method, :db => :us, :limit => 5)}.should_not raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,6 @@ require 'semrush' # and any other gems you need
 API_KEY = ENV['API_KEY'] || "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 
 RSpec.configure do |config|
-  # some (optional) config here
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
Right now the gem raises a map error when you give it an organic report that's filtered with no results. I've fixed that to just return an empty array.

Here's the error before the changes I added:

1) Reports: Semrush running domain reports handles domains with no keywords
     Failure/Error: keys = csv.shift.map(&format_key)

     NoMethodError:
       undefined method `map' for nil:NilClass
       Did you mean?  tap
     # ./lib/semrush/report.rb:354:in `parse'
     # ./lib/semrush/report.rb:286:in `request'
     # ./lib/semrush/report.rb:146:in `organic'
     # ./spec/semrush/report_spec.rb:26:in `block (3 levels) in <top (required)>'